### PR TITLE
Add .info-alert component styling

### DIFF
--- a/_sass/molecules/_alert.scss
+++ b/_sass/molecules/_alert.scss
@@ -1,5 +1,6 @@
 .alert {
   color: white;
+
   a {
     display: block;
     width: 100%;
@@ -11,6 +12,7 @@
     text-decoration: none;
     // text-align: center;
   }
+
   .alert-text {
     display: block;
     max-width: $site-max-width;
@@ -19,33 +21,30 @@
     margin-left: auto;
     margin-right: auto;
     font-size: .8rem;
+
     @include media($tablet-up) {
       font-size: inherit;
     }
   }
+
   .alert-link {
     text-decoration: underline;
     display: block;
     clear: left;
     margin-top: -.3rem;
+
     @include media($tablet-up) {
       display: inline;
       clear: none;
       margin-top: 0;
     }
   }
-  // padding: 1.5em $site-margins;
-  // border-bottom: 6px solid $color-grey-400;
-  // width: auto;
-  // margin: {
-  //   left: -$site-margins;
-  //   right: -$site-margins;
-  // }
-  // a {
-  //   color: $color-primary;
-  // }
 }
 
-// .blue-bg-alert a {
-//   background-color: $color-light-gray;
-// }
+.info-alert {
+  @extend .alert;
+
+  a {
+    border-bottom: 0;
+  }
+}


### PR DESCRIPTION
Even though `.info-alert` is mentioned in the style guide, it's not
defined in the stylesheets. I need a very basic alert component to
convey information about a page, for example, 'This page describes a
past project'. This commit adds a basic `.info-alert` component that
extends `.alert` and removes the bottom border.

We need to revisit the `.alert` component styling more holistically, but
for now I just want to use the lightest touch to add something very
basic.