### PR TITLE
Set background-size and background-position for hero elements

### DIFF
--- a/_sass/organisms/_hero.scss
+++ b/_sass/organisms/_hero.scss
@@ -1,5 +1,7 @@
 .hero {
   background-color: $color-blue;
+  background-position: center center;
+  background-size: cover;
 }
 
 .hero-content {


### PR DESCRIPTION
I'm adding the ability to specify a background image for header hero elements on the Code for
America website. This commit set some default properties for handling background images in hero
elements. Specifically, it makes the background image cover the hero element, and it positions the
background image 'center center'.