### PR TITLE
Change global alert background color on primary pages

### DIFF
--- a/_sass/templates/_primary-page.scss
+++ b/_sass/templates/_primary-page.scss
@@ -7,7 +7,7 @@
     margin-bottom: 1rem;
   }
   .alert a {
-    background-color: $color-dark-blue;
+    background-color: rgba(0,0,0,0.15);
     color: white;
     border-bottom: 0;
   }


### PR DESCRIPTION
Some primary pages will now have a header background image. This commit updates the alert
background color on primary pages so that, instead of being dark blue, they're now black and very
transparent. On most pages that have blue headers, the end results will look the same as it did
before.

![image](https://user-images.githubusercontent.com/8628090/39726854-4c2195a2-5205-11e8-97fe-7b774e2e538d.png)

![image](https://user-images.githubusercontent.com/8628090/39726891-6224ff7e-5205-11e8-956d-d46949eae8df.png)
