### PR TITLE
Add dark blue slab style

### DIFF
--- a/_sass/molecules/_slab.scss
+++ b/_sass/molecules/_slab.scss
@@ -72,6 +72,10 @@ main > .slab:last-child {
 }
 .blue-bg-slab {
   @extend %reverse-slab;
+  background-color: $color-blue;
+}
+.dark-blue-bg-slab {
+  @extend %reverse-slab;
   background-color: $color-dark-blue;
 }
 .green-bg-slab {


### PR DESCRIPTION
The stylesheet currently includes a blue background slab. A slight variation on the blue style would
be useful -- for example, the Summit 2018 branding uses medium blue and dark blue blocks next to
eachother. This commit updates `.blue-bg-slab` to use `$color-blue` instead of `$dark-blue`, and adds a `.dark-blue-bg-slab` variant that uses `$color-dark-blue` for its background-color.

This commit adds a dark blue slab style.