### PR TITLE
Make reverse-header text white

### DIFF
--- a/_sass/atoms/_typography.scss
+++ b/_sass/atoms/_typography.scss
@@ -63,42 +63,36 @@ h3, h4, h5, h6 {
   font-size: map-get($h1-styles, font-size);
   line-height: map-get($h1-styles, line-height);
   font-weight: map-get($h1-styles, font-weight);
-  color: map-get($h1-styles, color);
 }
 
 @mixin h2 {
   font-size: map-get($h2-styles, font-size);
   line-height: map-get($h2-styles, line-height);
   font-weight: map-get($h2-styles, font-weight);
-  color: map-get($h2-styles, color);
 }
 
 @mixin h3 {
   font-size: map-get($h3-styles, font-size);
   line-height: map-get($h3-styles, line-height);
   font-weight: map-get($h3-styles, font-weight);
-  color: map-get($h3-styles, color);
 }
 
 @mixin h4 {
   font-size: map-get($h4-styles, font-size);
   line-height: map-get($h4-styles, line-height);
   font-weight: map-get($h4-styles, font-weight);
-  color: map-get($h4-styles, color);
 }
 
 @mixin h5 {
   font-size: map-get($h5-styles, font-size);
   line-height: map-get($h5-styles, line-height);
   font-weight: map-get($h5-styles, font-weight);
-  color: map-get($h5-styles, color);
 }
 
 @mixin h6 {
   font-size: map-get($h6-styles, font-size);
   line-height: map-get($h6-styles, line-height);
   font-weight: map-get($h6-styles, font-weight);
-  color: map-get($h6-styles, color);
   text-transform: uppercase;
 }
 

--- a/_sass/organisms/_global-header.scss
+++ b/_sass/organisms/_global-header.scss
@@ -120,10 +120,16 @@
 .reverse-global-header {
   color: white;
 
+  .alert a {
+    background-color: rgba(0, 0, 0, 0.15);
+    border-bottom: 0;
+    color: white;
+  }
+
   .global-header-menu .menu-item {
     color: white;
   }
-  
+
   .global-header-menu .active-menu-item {
     color: white;
     font-weight: 600;

--- a/_sass/organisms/_global-header.scss
+++ b/_sass/organisms/_global-header.scss
@@ -118,9 +118,12 @@
 
 // For use on reverse backgrounds
 .reverse-global-header {
+  color: white;
+
   .global-header-menu .menu-item {
     color: white;
   }
+  
   .global-header-menu .active-menu-item {
     color: white;
     font-weight: 600;

--- a/_sass/templates/_home.scss
+++ b/_sass/templates/_home.scss
@@ -65,9 +65,6 @@
     }
   }
 
-  .slab > h3 {
-  }
-
   .alert a {
     border-bottom: 0;
     text-align: center;

--- a/_sass/templates/_home.scss
+++ b/_sass/templates/_home.scss
@@ -1,4 +1,5 @@
 .template-home {
+  
   .home-hero {
     @include clearfix;
     background-color: $color-grey-200;
@@ -18,6 +19,7 @@
     padding: 1rem $site-margins;
     position: relative;
   }
+
   .home-hero-content .grid-box {
     @include media($tablet-up) {
       min-height: 20rem;
@@ -25,10 +27,10 @@
       align-items: center;
     }
   }
+
   .home-hero-title {
     text-align: center;
       @include h3;
-      color: black;
       font-weight: 400;
     @include media($tablet-up) {
       @include h2;
@@ -39,6 +41,7 @@
       font-weight: 400;
     }
   }
+
   .home-hero-lead-in {
     text-align: center;
     font-weight: 400;
@@ -63,8 +66,8 @@
   }
 
   .slab > h3 {
-    color: $color-black;
   }
+
   .alert a {
     border-bottom: 0;
     text-align: center;


### PR DESCRIPTION
Make sure that reverse-header text is white. This includes removing aggressive properties to make headings black, to instead allow headings to inherit their color from their parent elements.