### PR TITLE
Add $hero-color variable for customization

### DIFF
--- a/_sass/organisms/_hero.scss
+++ b/_sass/organisms/_hero.scss
@@ -1,5 +1,7 @@
+$hero-color: $color-blue !default;
+
 .hero {
-  background-color: $color-blue;
+  background-color: $hero-color;
   background-position: center center;
   background-size: cover;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeforamerica/style",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Code for America's Styleguide. http://v4.style.codeforamerica.org",
   "main": "_site/js/site.js",
   "scripts": {


### PR DESCRIPTION
When importing these files separately, using a default-level variable
here will allow style guide users to change the hero color like so:

```sass
@import '~@codeforamerica/style/_sass/core/_variables.scss';

$hero-color: $color-red;

@import '~@codeforamerica/style/_sass/main.scss';
```