### PR TITLE
Only auto-deploy "cfa-dot-org" branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ after_success:
   - make dist
 branches:
   only:
-    - master
+    - cfa-dot-org


### PR DESCRIPTION
Since the main codeforamerica.org site hotlinks our style guide without
versioning, in order to make backwards incompatible changes on master,
we are creating a new branch "cfa-dot-org" that will remain
backwards-compatible with the existing styles until the
codeforamerica/cms repo can be modified to use the versioned npm build.