### PR TITLE
Add a quick new campaign-page template

### DIFF
--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -49,5 +49,6 @@
 @import 'templates/category';
 @import 'templates/article';
 @import 'templates/announcement';
+@import 'templates/campaign-page';
 @import 'templates/content';
 @import 'templates/primary-page';

--- a/_sass/templates/_campaign-page.scss
+++ b/_sass/templates/_campaign-page.scss
@@ -1,0 +1,29 @@
+.template-campaign-page {
+  .hero-content {
+    padding-bottom: 6rem;
+  }
+
+  .hero-title {
+    font-size: 4rem;
+    line-height: 4rem;
+    padding-right: 1em;
+  }
+
+  .call-to-action {
+    background-color: #fff;
+    padding: 1rem 2rem;
+  }
+
+  .call-to-action p {
+    color: $color-black;
+    font-size: 1.4rem;
+  }
+
+  .call-to-action .button {
+    width: 100%;
+  }
+
+  .action-card .button {
+    padding: 1em 3em;
+  }
+}


### PR DESCRIPTION
A fundraising campaign is starting tomorrow and there was a request from the development team to
set up a campaign donation page. This adds a campaign-page template to our style-guide. This is a
quick, messy addition and will need to be revisited.