### PR TITLE
Add `red-bg-slab` variant

### DIFF
--- a/_sass/molecules/_slab.scss
+++ b/_sass/molecules/_slab.scss
@@ -87,5 +87,6 @@ main > .slab:last-child {
   background-color: $color-shade-gray;
 }
 .red-bg-slab {
+  @extend %reverse-slab;
   background-color: $color-red;
 }

--- a/_sass/molecules/_slab.scss
+++ b/_sass/molecules/_slab.scss
@@ -86,3 +86,6 @@ main > .slab:last-child {
 .gray-bg-slab {
   background-color: $color-shade-gray;
 }
+.red-bg-slab {
+  background-color: $color-red;
+}


### PR DESCRIPTION
Craft supports creating an element with this class, but there was never
any implementation of the style.