### PR TITLE
 Add `$mobile-nav-background-color` to allow customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- Add `$mobile-nav-background-color` variable to allow customization
+
+## [4.0.1] - 2018-08-13
+### Added
+- Add a quick new cmapaign-page template
+- Add hero-color variable
+- Add .info-alert component styling
+- Add dark blue slab style
+- Add $hero-color variable for customization
+
+### Changed
+- Improve <label> styling and display in style guide
+- Set background-size and background-position for hero elements
+- Change global alert background color on primary pages
+- Make all text in reverse-slabs white
+- Make all text in reverse-global-header white
+- Remove aggressive color styling from headings and home template
+- Make reverse-global-header alerts white with dark transparent background
+- Clean up empty CSS rule-sets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [4.0.2] - 2018-08-14
 ### Added
 - Add `$mobile-nav-background-color` variable to allow customization
 

--- a/_sass/organisms/_mobile-navigation.scss
+++ b/_sass/organisms/_mobile-navigation.scss
@@ -1,3 +1,5 @@
+$mobile-nav-background-color: $color-dark-blue !default;
+
 .mobile-navigation.global-header-navigation {
   @media screen and (max-width: $tablet-up) {
     @include transition(opacity .25s ease-in-out);
@@ -8,7 +10,7 @@
     left: 0;
     bottom: 0;
     width: 100%;
-    background-color: $color-dark-blue;
+    background-color: $mobile-nav-background-color;
     display: block;
     z-index: -1;
     padding: 1rem;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeforamerica/style",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Code for America's Styleguide. http://v4.style.codeforamerica.org",
   "main": "_site/js/site.js",
   "scripts": {


### PR DESCRIPTION
Since the user can customize `$hero-color`, allowing customizable mobile
nav background color is necessary to prevent jarring transitions.