### PR TITLE
Add "card--white" variant

### DIFF
--- a/_sass/molecules/_card.scss
+++ b/_sass/molecules/_card.scss
@@ -132,3 +132,8 @@ a.supporter-card {
     margin-top: .25rem;
   }
 }
+
+.card--white {
+  background-color: $color-white;
+  border: 1px solid $color-light-gray;
+}


### PR DESCRIPTION
This is useful for displaying cards that have visual contrast against a
grey background. For example, this will be used on brigade profile
pages, and could be used on the job board featured jobs section.

Use it like:
`<div class="card card--white link-card">`