### PR TITLE
Remove anchor tag selector from card styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Update "card" selectors to not require cards be anchor tags
 
 ## [4.0.2] - 2018-08-14
 ### Added

--- a/_sass/molecules/_card.scss
+++ b/_sass/molecules/_card.scss
@@ -1,10 +1,15 @@
 .card {
+  color: inherit;
   margin: {
     top: 1rem;
     bottom: 1rem;
   }
   padding: 0;
   text-align: left;
+}
+
+a.card {
+  color: inherit;
 }
 
 .logo-card {

--- a/_sass/molecules/_card.scss
+++ b/_sass/molecules/_card.scss
@@ -17,14 +17,14 @@
 }
 
 // Shared styles for link/action cards
-a.action-card, a.link-card, a.index-card {
+.action-card, .link-card, .index-card {
   display: block;
   text-decoration: none;
   color: inherit;
 }
 
 // Link card
-a.link-card {
+.link-card {
   background-color: $color-shade-gray;
   overflow: hidden;
   .card-image {
@@ -37,12 +37,12 @@ a.link-card {
 }
 
 // Action card
-a.action-card {
+.action-card {
   text-align: center;
 }
 
 // Index card
-a.index-card {
+.index-card {
   border: 1px solid $color-light-gray;
   overflow: hidden;
   .card-image {
@@ -72,7 +72,7 @@ a.index-card {
 }
 
 // Index card
-a.supporter-card {
+.supporter-card {
   border: 1px solid $color-light-gray;
   overflow: hidden;
   text-align: center;

--- a/_sass/molecules/_card.scss
+++ b/_sass/molecules/_card.scss
@@ -1,5 +1,4 @@
 .card {
-  color: inherit;
   margin: {
     top: 1rem;
     bottom: 1rem;


### PR DESCRIPTION
This is a retry of #20 which I accidentally merged.

There are many reasons to not assume that an entire card is a link: if
you don't want the whole card to be a link, if you want to have multiple
links inside the card, and just in general if you want to use a card for
a non-linking purpose.

By removing the from these selectors we can make the cards more
versatile.