### PR TITLE
Add margin-bottom to message component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Add $global-header-logo-width and $global-haeder-logo-width-mobile variables
 
 ## [4.0.5] - 2018-09-06
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ## [4.0.6] - 2018-09-06
-- Add $global-header-logo-width and $global-haeder-logo-width-mobile variables
+### Added
+- Add $global-header-logo-width and $global-header-logo-width-mobile variables
 
 ## [4.0.5] - 2018-09-06
-### Changed
-- Added margin-bottom to "message" component
+### Added
+- Add margin-bottom to "message" component
 
 ## [4.0.4] - 2018-08-28
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [4.0.5] - 2018-09-06
 ### Changed
 - Added margin-bottom to "message" component
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [4.0.6] - 2018-09-06
 - Add $global-header-logo-width and $global-haeder-logo-width-mobile variables
 
 ## [4.0.5] - 2018-09-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Added margin-bottom to "message" component
 
 ## [4.0.4] - 2018-08-28
 ### Added

--- a/_sass/molecules/_message.scss
+++ b/_sass/molecules/_message.scss
@@ -3,6 +3,7 @@
   color: $color-red;
   display: flex;
   flex-direction: row;
+  margin-bottom: 1rem;
   padding: 0.5rem 1rem;
   text-decoration: none;
 

--- a/_sass/organisms/_global-header.scss
+++ b/_sass/organisms/_global-header.scss
@@ -1,3 +1,6 @@
+$global-header-logo-width-mobile: 100px !default;
+$global-header-logo-width: 150px !default;
+
 .global-header {
   @include clearfix();
 
@@ -32,9 +35,10 @@
   // top: .2em;
 
   img {
-    max-width: 100px;
+    max-width: $global-header-logo-width-mobile;
+
     @include media($tablet-up) {
-      max-width: 150px;
+      max-width: $global-header-logo-width;
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeforamerica/style",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "description": "Code for America's Styleguide. http://v4.style.codeforamerica.org",
   "main": "_site/js/site.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeforamerica/style",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "description": "Code for America's Styleguide. http://v4.style.codeforamerica.org",
   "main": "_site/js/site.js",
   "scripts": {


### PR DESCRIPTION
This will improve spacing, especially in the case of two messages
adjacent to each other.

E.g.
![image](https://user-images.githubusercontent.com/129120/45186028-0259d600-b1e1-11e8-9516-6cb5a254cb2c.png)


See: codeforamerica/brigade#568