### PR TITLE
Make lead-in-text a smidge darker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Darken .lead-in-text to improve contrast against white backgrounds
+
 ## [4.0.7] - 2018-09-06
 ### Added
 - Add three variables to customize "alert" molecule appearance.

--- a/_sass/atoms/_typography.scss
+++ b/_sass/atoms/_typography.scss
@@ -141,7 +141,7 @@ h6, .h6 {
 .lead-in-text {
   font-size: map-get($h4-styles, font-size);
   line-height: map-get($h4-styles, line-height);
-  color: $color-gray;
+  color: $color-dark-gray;
   margin-bottom: $large-spacing;
 }
 


### PR DESCRIPTION
To improve its contrast against a white background, let's make it a bit
darker. This will make it AA compliant at size 20px. (Though, not AAA).