### PR TITLE
Add styling for border-bottom-slab

### DIFF
--- a/_molecules/slabs.md
+++ b/_molecules/slabs.md
@@ -24,3 +24,25 @@ Common uses of slab sections would to be include a header and custom layout of e
     </div>
   </section>
 </div>
+
+### Border-top slab
+{: .styleguide-heading }
+
+<div class="preview">
+  <section class="slab border-top-slab">
+    <div class="grid-box">
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit. Commodi enim provident, nisi mollitia similique, veritatis voluptates at atque sint deserunt magni, laudantium eius. Illum ipsum esse corporis, odit sit. Consequuntur.
+    </div>
+  </section>
+</div>
+
+### Border-bottom slab
+{: .styleguide-heading }
+
+<div class="preview">
+  <section class="slab border-bottom-slab">
+    <div class="grid-box">
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit. Dolorum illum dolorem fugiat odio consectetur, molestias sit voluptatibus, impedit laborum libero autem, eum esse iusto aliquid nihil. Quod qui perspiciatis tempore.
+    </div>
+  </section>
+</div>

--- a/_sass/molecules/_slab.scss
+++ b/_sass/molecules/_slab.scss
@@ -57,6 +57,15 @@ main > .slab:last-child {
   // border-top: 1px solid $color-light-gray;
 }
 
+.border-bottom-slab {
+  @extend .border-top-slab;
+
+  &:before {
+    top: auto; 
+    bottom: 0;
+  }
+}
+
 .tight-slab {
   padding: 2rem $site-margins;
   @include media($tablet-up) {


### PR DESCRIPTION
The styleguide has styling for the `.border-top-slab` slab variant, but not for `.border-bottom-slab`, even though it's already set up in the CMS. This adds the same basic styling for the bottom-border slab.

I don't think the way that slabs (and other layout components) are styled/set up at the moment is optimal, and we're going to move to some better patterns very soon. This is intended as an interim fix.