### PR TITLE
Add a jumbo variant of the hero component

### DIFF
--- a/_sass/organisms/_hero.scss
+++ b/_sass/organisms/_hero.scss
@@ -6,17 +6,38 @@ $hero-color: $color-blue !default;
   background-size: cover;
 }
 
-.hero-content {
+.hero__content, .hero-content {
   h1,h2,h3,h4,h5,h6,p,a {
     color: white;
     font-weight: 600;
   }
-  padding: {
-    left: $site-margins;
-    right: $site-margins;
-    bottom: 2rem;
-  }
+
+  padding-left: $site-margins;
+  padding-right: $site-margins;
+  padding-bottom: 2rem;
+
   @include media($tablet-up) {
     padding-bottom: 3rem;
   }
 }
+
+.hero--jumbo {
+  .hero__content {
+    align-items: center;
+    display: flex;
+    justify-content: center;
+    min-height: 80vh;
+    padding: 3em 1em;
+  }
+
+  .hero__title {
+    font-size: 2em;
+    line-height: 1;
+    margin-bottom: 1em;
+
+    @include media($tablet-up) {
+      font-size: 4em;
+    }
+  }
+}
+


### PR DESCRIPTION
I'm adding a 'jumbo' variant of the hero component to be used in a new 'major events' template, for events like Summit. It has a bit of drama: it takes up most most (80%) of the vertical space of the screen and its content is displayed in its center.

This also add some styling of the sub-components of `hero--jumbo`, and starts including some BEM class names for the parts of the `slab` component, as we move towards BEM classic as a naming convention.