### PR TITLE
Add column class names that start with 'col' followed by integer

### DIFF
--- a/_sass/core/_grid.scss
+++ b/_sass/core/_grid.scss
@@ -42,40 +42,40 @@
     }
 
     // Different notation
-    .span-one {
+    .col-1, .span-one {
       @include span-columns(1);
     }
-    .span-two {
+    .col-2, .span-two {
       @include span-columns(2);
     }
-    .span-three {
+    .col-3, .span-three {
       @include span-columns(3);
     }
-    .span-four {
+    .col-4, .span-four {
       @include span-columns(4);
     }
-    .span-five {
+    .col-5, .span-five {
       @include span-columns(5);
     }
-    .span-six {
+    .col-6, .span-six {
       @include span-columns(6);
     }
-    .span-seven {
+    .col-7, .span-seven {
       @include span-columns(7);
     }
-    .span-eight {
+    .col-8, .span-eight {
       @include span-columns(8);
     }
-    .span-nine {
+    .col-9, .span-nine {
       @include span-columns(9);
     }
-    .span-ten {
+    .col-10, .span-ten {
       @include span-columns(10);
     }
-    .span-elevent {
+    .col-11, .span-eleven {
       @include span-columns(11);
     }
-    .span-twelve {
+    .col-12, .span-twelve {
       @include span-columns(12);
     }
 


### PR DESCRIPTION
In a 12 column grid, it's now pretty standard for the column classes to follow a naming convention that looks something like `col-3`, `col-6` etc. I want to introduce a bit more flexibility with the placement of components into grids in the CMS, and having the column class names in this more-standard format will make it easier to do so.