### PR TITLE
Add some BEM class names for standard card subcomponents

### DIFF
--- a/_sass/molecules/_card.scss
+++ b/_sass/molecules/_card.scss
@@ -94,45 +94,45 @@ a.card {
 
 // Subcomponents for all cards
 
-.card-content {
+.card__content, .card-content {
   padding: 1rem;
 }
 
-.card-button {
+.card__button, .card-button {
   display: inline-block;
   margin: .5rem 0 0;
 }
 
-.card-link {
+.card__link, .card-link {
   @extend a;
   a.card:hover & {
     text-decoration: underline;
   }
 }
 
-.card-icon {
+.card__icon, .card-icon {
   margin-top: .5rem;
   margin-bottom: .5rem;
   max-width: 125px;
 }
 
-.card-image {
+.card__image, .card-image {
 
 }
 
-.card-overhead {
+.card__overhead, .card-overhead {
   @include h6;
   margin-top: $large-spacing;
   margin-bottom: 0;
 }
 
-.card-title {
+.card__title, .card-title {
   @include h4;
 
-  &.card-link {
+  &.card__link, &.card-link {
     @extend a;
   }
-  .card-overhead + & {
+  .card__overhead + &, .card-overhead + & {
     margin-top: .25rem;
   }
 }


### PR DESCRIPTION
We're moving towards BEM classic and, as I'm modifying templates and building new ones, I'm adding BEM-style class names to some of our existing components and subcomponents.

Some of the card variants still need to be BEM-ified in the future, like link-cards and supporters-cards etc.