### PR TITLE
Add a 'grid-row' layout component

### DIFF
--- a/_sass/core/_grid.scss
+++ b/_sass/core/_grid.scss
@@ -165,3 +165,29 @@
     }
   }
 }
+
+.grid-row {
+  @include media($tablet-up) {
+    display: flex;
+    flex-direction: row;
+    align-items: stretch;
+  }
+
+  @for $i from 1 through 8 {
+    .col-#{$i} {
+      display: flex;
+    }
+  }
+}
+
+.grid-row__item {
+  @include media($tablet-up) {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+
+    & > * {
+      flex: 1;
+    }
+  }
+}


### PR DESCRIPTION
I'm adding a `content-grid-row` component to the codeforamerica.org CMS and this adds some styling, harnessing flexbox, to help align the sub-elements and make sure they're all the same height (on wider screens).