### PR TITLE
Make the grid sizing of the grid row sub-element less agressive

### DIFF
--- a/_sass/core/_grid.scss
+++ b/_sass/core/_grid.scss
@@ -176,6 +176,7 @@
   @for $i from 1 through 8 {
     .col-#{$i} {
       display: flex;
+      flex-direction: column;
     }
   }
 }
@@ -184,10 +185,6 @@
   @include media($tablet-up) {
     display: flex;
     flex-direction: column;
-    justify-content: center;
-
-    & > * {
-      flex: 1;
-    }
+    justify-content: top;
   }
 }

--- a/_sass/molecules/_card.scss
+++ b/_sass/molecules/_card.scss
@@ -5,6 +5,7 @@
   }
   padding: 0;
   text-align: left;
+  flex: 1;
 }
 
 a.card {


### PR DESCRIPTION
Previously all elements in a grid-row column would size up to the full height of the column, but there are some situations where I want to stack two sub-elements in one column element and the alignment was getting a bit screwy. This fixes those alignment issues, and makes cards take up the full height of the row, so I can still do rows of cards that all the same height.