### PR TITLE
Make stat labels more compact

### DIFF
--- a/_sass/atoms/_stat.scss
+++ b/_sass/atoms/_stat.scss
@@ -16,7 +16,5 @@ $stat-label-color: $color-darkest-blue !default;
 
 .stat__label {
   color: $stat-number-color;
-  font-size: 1.2em;
   font-weight: 600;
-  letter-spacing: 1px;
 }


### PR DESCRIPTION
With the larger font-size and the added letter-spacing, some longer labels were looking too bloated. Let's remove these properties to make them more compact.