### PR TITLE
Make blockquotes dark blue, instead of red

### DIFF
--- a/_sass/atoms/_blockquote.scss
+++ b/_sass/atoms/_blockquote.scss
@@ -1,6 +1,6 @@
 blockquote {
   font-size: map-get($h4-styles, font-size);
-  color: $color-red;
+  color: $color-darkest-blue;
   margin: ($large-spacing * 1.5) 0;
 }
 


### PR DESCRIPTION
We mostly use red for interactive elements, so I'm making quotes dark blue.