### PR TITLE
Use full URL for open-quotes image

### DIFF
--- a/_sass/atoms/_blockquote.scss
+++ b/_sass/atoms/_blockquote.scss
@@ -6,7 +6,7 @@ blockquote {
   position: relative;
 
   &:before {
-    background-image: url('/media/images/open-quotes.png');
+    background-image: url('https://v4.style.codeforamerica.org/media/images/open-quotes.png');
     background-repeat: no-repeat;
     background-size: 100% auto;
     content: "";


### PR DESCRIPTION
The open quotes image isn't rendering in production. This adds the full URL for the image file, to make sure the image renders. This isn't an ideal implementation, but rather a quick fix. Ideally I'd like the quotes to be done using text only, and once we've updated the website fonts to Proxima Nova (for consistency with our other marketing materials), I'll change this out.