### PR TITLE
Darken gray shade to increase contrast between slabs

### DIFF
--- a/_sass/core/_variables.scss
+++ b/_sass/core/_variables.scss
@@ -20,7 +20,7 @@ $color-black:       #000000;
 $color-gray:        #9d9d9d;
 $color-light-gray:  #d8d8d8;
 $color-dark-gray:   #6b6b6b;
-$color-shade-gray:  #f9f9f9;
+$color-shade-gray:  #f5f5f5;
 $color-red:         #cd1f42;
 $color-light-red:   #d5405e;
 $color-dark-red:    #bd1b3c;


### PR DESCRIPTION
A common pattern on codeforamerica.org is to alternate white-bg and gray-bg slabs, but the contrast between the two backgrounds is quite low and one some devices (esp. on mobile) one might not even notice the variation in background colors. This darkens the gray-shade variable, used in gray-background-slabs, to the same shade that is used in the global footer.