### PR TITLE
Add darkest-blue slab variant

### DIFF
--- a/_sass/molecules/_slab.scss
+++ b/_sass/molecules/_slab.scss
@@ -110,6 +110,12 @@ main > .slab:last-child {
   background-color: $color-dark-blue;
 }
 
+.slab--darkest-blue,
+.darkest-blue-bg-slab {
+  @extend %reverse-slab;
+  background-color: $color-darkest-blue;
+}
+
 .slab--green,
 .green-bg-slab {
   @extend %reverse-slab;


### PR DESCRIPTION
The Summit branding makes use of a very dark shade of blue that we want to use on the Summit website. This adds a darkest-blue variant of the slab component, that uses that blue as a background color.