### PR TITLE
Use flexbox to vertically align logos

### DIFF
--- a/_sass/molecules/_logos.scss
+++ b/_sass/molecules/_logos.scss
@@ -1,14 +1,18 @@
 .logos {
-  margin: {
-    top: 1rem;
-    bottom: 1rem;
-  }
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-bottom: 1rem;
+  margin-top: 1rem;
 }
+
 .logo-item, a.logo-item {
-  display: inline-block;
-  margin: .25rem 0;
-  width: 30%;
+  align-items: center;
+  display: flex;
+  margin: 0.25rem 0;
   padding: 5px;
+  width: 30%;
+
   @include media($tablet-up) {
     width: 15%;
     padding: 20px;


### PR DESCRIPTION
Logos (like the press logos on the codeforamerica.org homepage) aren't vertically centered next to eachother. This adds some flexbox properties to make sure they line up neatly.