### PR TITLE
Size and position background images in slabs

### DIFF
--- a/_sass/molecules/_slab.scss
+++ b/_sass/molecules/_slab.scss
@@ -1,6 +1,8 @@
 .slab {
   @include clearfix;
   display: block;
+  background-size: cover;
+  background-position: center center;
   margin: {
     left: -$site-margins;
     right: -$site-margins;


### PR DESCRIPTION
It's now possible in the codeforamerica.org CMS to specify a background image for content block 'slabs'. This adds some background size and position properties to slabs.