### PR TITLE
Feature/larger stat labels

### DIFF
--- a/_sass/atoms/_stat.scss
+++ b/_sass/atoms/_stat.scss
@@ -9,7 +9,7 @@ $stat-label-color: $color-darkest-blue !default;
 
 .stat__number {
   color: $stat-number-color;
-  font-size: 4em;
+  font-size: 4rem;
   font-weight: 600;
   line-height: 1.2em;
 }

--- a/_sass/atoms/_stat.scss
+++ b/_sass/atoms/_stat.scss
@@ -16,5 +16,6 @@ $stat-label-color: $color-darkest-blue !default;
 
 .stat__label {
   color: $stat-number-color;
+  font-size: 1.1rem;
   font-weight: 600;
 }


### PR DESCRIPTION
This updates `.stat__number` to use an REM font-size, and slightly increases the font-size of the labels (in response to some design feedback).