### PR TITLE
Add card-grid component

### DIFF
--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -39,12 +39,13 @@
 
 // Organisms (complex components)
 @import 'organisms/billboard';
-@import 'organisms/hero';
-@import 'organisms/page-header';
-@import 'organisms/global-header';
+@import 'organisms/card-grid';
 @import 'organisms/global-footer';
-@import 'organisms/mobile-navigation';
+@import 'organisms/global-header';
+@import 'organisms/hero';
 @import 'organisms/index-card-list';
+@import 'organisms/mobile-navigation';
+@import 'organisms/page-header';
 @import 'organisms/supporter-card-list';
 
 // Page Templates

--- a/_sass/organisms/_card-grid.scss
+++ b/_sass/organisms/_card-grid.scss
@@ -1,0 +1,14 @@
+.card-grid {
+  @include media($tablet-up) {
+    display: flex;
+    flex-flow: row wrap;
+
+    .card-grid__item {
+      padding-bottom: 2rem;
+    }
+
+    .card {
+      height: 100%;
+    }
+  }
+}


### PR DESCRIPTION
This adds some simple styling for a card-grid component. The main purpose is to give cards that apprear on the same row, the same height. This styling only applies on wider screens, when cards aren't stacked.

Also sorted the organism imports alphabetically.