### PR TITLE
Make card images a standard size

### DIFF
--- a/_sass/molecules/_card.scss
+++ b/_sass/molecules/_card.scss
@@ -23,6 +23,18 @@ a.card {
 
 // Card subcomponents
 
+.card__image {
+  background-position: center center;
+  background-repeat: no-repeat;
+  background-size: cover;
+  border-bottom : 1px solid $color-light-gray;
+  padding-top: 66.66%;
+}
+
+.card__image--contained {
+  background-size: auto 80%;
+}
+
 .card__content,
 .card-content {
   padding: 1rem;


### PR DESCRIPTION
To make card image appear more consistent across codeforamerica.org, I'm moving to approach whereby card images are shown as a background images in a `div.card__image` component. 

This commit adds some background-image properties to the `.card__image` subcomponent, makes card iamges have an aspect ratio of 4:3 (by using a padding property hack), and adds a `card__image--contained` variant for when the image should appear smaller and centered (for example, for a logo).