### PR TITLE
Make alerts not always be bold

### DIFF
--- a/_sass/molecules/_alert.scss
+++ b/_sass/molecules/_alert.scss
@@ -2,7 +2,6 @@
   background-color: $color-shade-gray;
   box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.2);
   color: $color-red;
-  font-weight: 600;
   padding: 0.5rem 0;
 
   a {


### PR DESCRIPTION
Sometimes we might want to make part of an alert bold, or might want to add a subtle alert that isn't bold at all. Let's remove the font-weight property.