### PR TITLE
Remove top-margin from global-footer and bottom-margin from last slab

### DIFF
--- a/_sass/molecules/_slab.scss
+++ b/_sass/molecules/_slab.scss
@@ -21,14 +21,6 @@
   }
 }
 
-// If a slab is the last item in main, pull the footer up to meet it
-main > .slab:last-child {
-  margin-bottom: -2rem;
-  @include media($tablet-up) {
-    margin-bottom: -4rem;
-  }
-}
-
 .slab-title {
   @include h3;
   color: $color-black;

--- a/_sass/organisms/_global-footer.scss
+++ b/_sass/organisms/_global-footer.scss
@@ -1,7 +1,6 @@
 .global-footer {
   background-color: $color-grey-100;
   border-top: 1px solid $color-grey-300;
-  margin-top: 4em;
   padding: 2em $site-margins;
   font-size: $small-font-size;
   color: $color-grey-600;


### PR DESCRIPTION
The margins mean that blocks and their subelement aren't sitting flush with the global-footer. 
![image](https://user-images.githubusercontent.com/8628090/50939226-d4a3c880-1430-11e9-8db4-697ef9258548.png)

I think the way that these margins are set up is overly complicated, so this removes the margins for now.