### PR TITLE
Make action cards transparent

### DIFF
--- a/_sass/molecules/_card.scss
+++ b/_sass/molecules/_card.scss
@@ -95,6 +95,7 @@ a.supporter-card {
 a.card--action,
 .action-card,
 a.action-card {
+  background-color: transparent;
   border: none;
   text-align: center;
 


### PR DESCRIPTION
A change in the base card element meant that the action cards had a white background. This makes them transparent again.