### PR TITLE
Remove duplicate slab color variant declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Remove duplicate slab color variant declarations
 
 ## [5.0.0] - 2019-02-25
 - Too many changes to list. See the commit log for individual changes.

--- a/_sass/molecules/_slab.scss
+++ b/_sass/molecules/_slab.scss
@@ -82,8 +82,7 @@
   background-color: $color-lightest-gray;
 }
 
-.slab--darkest-gray,
-.gray-bg-slab {
+.slab--darkest-gray {
   @extend %reverse-slab;
   background-color: $color-darkest-gray;
 }
@@ -94,8 +93,7 @@
   background-color: $color-dark-red;
 }
 
-.slab--darkest-red,
-.red-bg-slab {
+.slab--darkest-red {
   @extend %reverse-slab;
   background-color: $color-darkest-red;
 }


### PR DESCRIPTION
I accidentally included two declarations for `.gray-bg-slab` and `.red-bg-slab` in the `slab` style sheet. As a result, gray slabs on the website are now way too dark and we only want them to be light gray. 
This fixes the mistake.