### PR TITLE
Release v5.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [5.0.1] - 2019-02-27
 ### Fixed
 - Remove duplicate slab color variant declarations
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeforamerica/style",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Code for America's Styleguide. http://v4.style.codeforamerica.org",
   "main": "_site/js/site.js",
   "scripts": {


### PR DESCRIPTION
This version includes a minor fix to the slab variants that's required for some work I'm doing on the codeforamerica.org templates.