### PR TITLE
Let slab headings be the same color as other text in the slab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Remove aggressive color declarations
 - Make card text black
+- Let slab headings be the same color as other text in the slab
 
 ## [5.0.1] - 2019-02-27
 ### Fixed

--- a/_sass/molecules/_slab.scss
+++ b/_sass/molecules/_slab.scss
@@ -23,7 +23,6 @@
 
 .slab-title {
   @include h3;
-  color: $color-black;
   font-weight: 600;
 }
 


### PR DESCRIPTION
In reverse slabs, we want the headings to be the same color as the rest of the text (white). Let's remove the declaration that makes slab headings black.