### PR TITLE
Auto-deploy the master branch of the styleguide

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ after_success:
   - make dist
 branches:
   only:
-    - cfa-dot-org
+    - master


### PR DESCRIPTION
Now that codeforamerica.org doesn't hotlink to the style guid anylonger, we can auto deploy the master branch with all the v5 changes.